### PR TITLE
Fix date/time in the p2000 message (and duplicates)

### DIFF
--- a/custom_components/p2000/sensor.py
+++ b/custom_components/p2000/sensor.py
@@ -143,7 +143,7 @@ class P2000Data:
                             continue
                         self._lastmsg_time = lastmsg_time
 
-                        eventmsg = item.title.replace("~", "") + "\n" + pubdate + "\n"
+                        eventmsg = item.title.replace("~", "") + "\n" + item.published + "\n"
                         _LOGGER.debug("New emergency event found: %s", eventmsg)
 
                         if "geo_lat" in item:


### PR DESCRIPTION
If the newest entry is skipped, the next check entry could get the wrong timestamp (using N, not N-1, N-2, etc).