### PR TITLE
Replace device_state_attributes with extra_state_attributes

### DIFF
--- a/custom_components/p2000/sensor.py
+++ b/custom_components/p2000/sensor.py
@@ -346,7 +346,7 @@ class P2000Sensor(RestoreEntity):
         self.async_schedule_update_ha_state(True)
 
     @property
-    def device_state_attributes(self):
+    def extra_state_attributes(self):
         """Return the state attributes."""
         attrs = {}
         data = self._data.latest_data


### PR DESCRIPTION
With 2021.12 we get a log, this PR fixes that.

Log:
```
implements device_state_attributes. Please report it to the custom component author.
```